### PR TITLE
[提出] 演習11: Next.jsブログ - Sakiko Yamasaki

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -5,19 +5,26 @@ import Image from "next/image";
 import { getAllSlugs, getPostBySlug } from "@/lib/markdown";
 import { formatJa, readingTimeJa } from "@/lib/utils";
 import TableOfContents from "@/components/blog/TableOfContents";
+type MaybePromise<T> = T | Promise<T>;
+type BlogPageProps = {
+  params: Promise<{ slug: string }>;
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+};
+
 
 export const revalidate = 3600;
 
 // 静的生成するパス
-export async function generateStaticParams() {
+export function generateStaticParams(): { slug: string }[] {
   return getAllSlugs().map((slug) => ({ slug }));
 }
 
 // 記事ごとの SEO メタデータ
 export async function generateMetadata(
-  { params }: { params: { slug: string } }
-): Promise<Metadata> {
-  const post = await getPostBySlug(params.slug);
+  { params }: BlogPageProps
+): Promise<Metadata> { 
+  const { slug } = await params;
+  const post = await getPostBySlug(slug); 
   if (!post || !post.published) return {};
 
   const siteUrl =
@@ -46,9 +53,9 @@ export async function generateMetadata(
     },
   };
 }
-
-export default async function PostPage({ params }: { params: { slug: string } }) {
-  const post = await getPostBySlug(params.slug);
+export default async function PostPage({ params }: BlogPageProps) {
+  const { slug } = await params;
+  const post = await getPostBySlug(slug);
   if (!post || !post.published) notFound();
 
   const timeLabel = readingTimeJa(post.contentHtml);

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,21 +1,22 @@
-// src/app/blog/page.tsx
 import Link from "next/link";
 import Image from "next/image";
 import { getAllPosts } from "@/lib/markdown";
 import { formatJa } from "@/lib/utils";
 import SearchBox from "./SearchBox";
+type MaybePromise<T> = T | Promise<T>;
+type BlogIndexPageProps = {
+  searchParams?: Promise<{ page?: string }>;
+};
 
 export const revalidate = 3600;
 
-type Props = {
-  searchParams?: { page?: string };
-};
 
-export default async function BlogPage({ searchParams }: Props) {
+export default async function BlogPage({ searchParams }: BlogIndexPageProps) {
+  const sp = await searchParams;
   const all = await getAllPosts();
 
   // --- 簡易ページネーション ---
-  const page = Math.max(1, Number(searchParams?.page ?? 1));
+  const page = Math.max(1, Number(sp?.page ?? 1));
   const perPage = 3;
   const start = (page - 1) * perPage;
   const posts = all.slice(start, start + perPage);

--- a/src/app/blog/tag/[tag]/page.tsx
+++ b/src/app/blog/tag/[tag]/page.tsx
@@ -3,18 +3,21 @@ import Link from "next/link";
 import Image from "next/image"; // ← 追加
 import { getPostsByTag } from "@/lib/markdown";
 import { formatJa } from "@/lib/utils";
+type TagPageProps = {
+  params: Promise<{ tag: string }>;
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+};
 
 export const revalidate = 3600;
 
-type Params = { params: { tag: string } };
-
-export default async function TagPage({ params }: Params) {
-  const tag = decodeURIComponent(params.tag);
-  const posts = await getPostsByTag(tag);
+export default async function TagPage({ params }: TagPageProps) {
+  const { tag } = await params;
+  const decoded = decodeURIComponent(tag);
+  const posts = await getPostsByTag(decoded);
 
   return (
     <section className="max-w-[960px] mx-auto p-4">
-      <h1 className="text-3xl font-extrabold mb-4">#{tag} の記事</h1>
+      <h1 className="text-3xl font-extrabold mb-4">#{decoded} の記事</h1>
 
       {posts.length === 0 ? (
         <p className="text-white/90">該当記事がありません。</p>


### PR DESCRIPTION
## 実装内容
- ブログ一覧ページ /blog
- 記事詳細ページ /blog/[slug]
- タグページ /blog/tag/[tag]（日本語タグ対応済み）
- OGP用メタ生成
- UI調整（レスポンシブ・カード表示）

## 記事
- 技術ブログ記事 7 本

## 動作確認URL
- https://next-blog-sandy-xi.vercel.app

## 起動手順
- npm install
- npm run dev
